### PR TITLE
Removed SKK currency support.  #11903

### DIFF
--- a/gold_digger/config/params.py
+++ b/gold_digger/config/params.py
@@ -26,12 +26,13 @@ DEFAULT_CONFIG_PARAMS = {
         "MCF", "MDL", "MGA", "MKD", "MMK", "MNT", "MOP", "MRO", "MTL", "MUR", "MVR", "MWK", "MXN",
         "MYR", "MZN", "NAD", "NGN", "NIO", "NLG", "NOK", "NPR", "NZD", "OMR", "PAB", "PEN", "PGK",
         "PHP", "PKR", "PLN", "PTE", "PYG", "QAR", "RON", "RSD", "RUB", "RWF", "SAR", "SBD", "SCR",
-        "SDG", "SEK", "SGD", "SHP", "SIT", "SKK", "SLL", "SML", "SOS", "SRD", "STD", "SYP",
-        "SZL", "THB", "TJS", "TMT", "TND", "TOP", "TRY", "TTD", "TWD", "TZS", "UAH", "UGX", "USD",
-        "UYU", "UZS", "VAL", "VEB", "VEF", "VND", "VUV", "WST", "XAF", "XAG", "XAU", "XCD", "XCP",
-        "XDR", "XOF", "XPD", "XPF", "XPT", "YER", "ZAR", "ZMK", "ZMW", "ZWL"
+        "SDG", "SEK", "SGD", "SHP", "SIT", "SLL", "SML", "SOS", "SRD", "STD", "SYP", "SZL", "THB",
+        "TJS", "TMT", "TND", "TOP", "TRY", "TTD", "TWD", "TZS", "UAH", "UGX", "USD", "UYU", "UZS",
+        "VAL", "VEB", "VEF", "VND", "VUV", "WST", "XAF", "XAG", "XAU", "XCD", "XCP", "XDR", "XOF",
+        "XPD", "XPF", "XPT", "YER", "ZAR", "ZMK", "ZMW", "ZWL"
     },
     "secrets": {
         "currency_layer": []
     },
 }
+


### PR DESCRIPTION
http://is.roihunter.com/issues/11903

@miso-belica I was unable to find who is requesting "SSK" currency data. I only found that fishy has old data too. Check [this](https://github.com/business-factory/fish-parser/blob/dev/fishy/utils/currency.py#L168) and there are more currencies which are no longer supported by Facebook according to [this page](https://developers.facebook.com/docs/marketing-api/currencies). I think, I should remove them from there.

@business-factory/pythonistas Please review and merge. 