### PR TITLE
Don't request unsupported rates from providers #18081

### DIFF
--- a/gold_digger/config/di.py
+++ b/gold_digger/config/di.py
@@ -72,7 +72,7 @@ class DiContainer:
         return (
             GrandTrunk(self.logger),
             CurrencyLayer(self["secrets"]["currency_layer"], self.logger),
-            Yahoo(self.logger),
+            Yahoo(self["supported_currencies"], self.logger),
             Google(self.logger),
             Fixer(self.logger),
         )

--- a/gold_digger/data_providers/_provider.py
+++ b/gold_digger/data_providers/_provider.py
@@ -11,6 +11,11 @@ class Provider(metaclass=ABCMeta):
     def __init__(self, logger):
         self.logger = logger
 
+    @property
+    @abstractmethod
+    def name(self):
+        pass
+
     @abstractmethod
     def get_supported_currencies(self, date_of_exchange):
         pass

--- a/gold_digger/data_providers/_provider.py
+++ b/gold_digger/data_providers/_provider.py
@@ -8,6 +8,8 @@ from decimal import Decimal, InvalidOperation
 
 
 class Provider(metaclass=ABCMeta):
+    DEFAULT_REQUEST_TIMEOUT = 15  # 15 seconds for both connect & read timeouts
+
     def __init__(self, logger):
         self.logger = logger
 
@@ -34,23 +36,23 @@ class Provider(metaclass=ABCMeta):
 
     def _get(self, url, params=None):
         try:
-            response = requests.get(url, params=params)
+            response = requests.get(url, params=params, timeout=self.DEFAULT_REQUEST_TIMEOUT)
             if response.status_code == 200:
                 return response
             else:
-                self.logger.error("%s get %s status code on %s. Params: %s." % (self, response.status_code, url, params))
+                self.logger.error("%s - status code: %s, URL: %s, Params: %s", self, response.status_code, url, params)
         except requests.exceptions.RequestException as e:
-            self.logger.error("%s get %s exception on %s. Params: %s." % (self, e, url, params))
+            self.logger.error("%s - exception: %s, URL: %s, Params: %s", self, e, url, params)
 
-    def _post(self, url, **kwargs):
+    def _post(self, url, params=None):
         try:
-            response = requests.post(url, **kwargs)
+            response = requests.post(url, params=params, timeout=self.DEFAULT_REQUEST_TIMEOUT)
             if response.status_code == 200:
                 return response
             else:
-                self.logger.error("%s get %s status code on %s" % (self, response.status_code, url))
+                self.logger.error("%s - status code: %s, URL: %s, Params: %s", self, response.status_code, url, params)
         except requests.exceptions.RequestException as e:
-            self.logger.error("%s get %s exception on %s" % (self, e, url))
+            self.logger.error("%s - exception: %s, URL: %s, Params: %s", self, e, url, params)
 
     def _to_decimal(self, value, currency=""):
         try:

--- a/gold_digger/data_providers/_provider.py
+++ b/gold_digger/data_providers/_provider.py
@@ -12,6 +12,10 @@ class Provider(metaclass=ABCMeta):
         self.logger = logger
 
     @abstractmethod
+    def get_supported_currencies(self, date_of_exchange):
+        pass
+
+    @abstractmethod
     def get_by_date(self, date_of_exchange, currency):
         pass
 

--- a/gold_digger/data_providers/_provider.py
+++ b/gold_digger/data_providers/_provider.py
@@ -29,9 +29,9 @@ class Provider(metaclass=ABCMeta):
             if response.status_code == 200:
                 return response
             else:
-                self.logger.error("%s get %s status code on %s" % (self, response.status_code, url))
+                self.logger.error("%s get %s status code on %s. Params: %s." % (self, response.status_code, url, params))
         except requests.exceptions.RequestException as e:
-            self.logger.error("%s get %s exception on %s" % (self, e, url))
+            self.logger.error("%s get %s exception on %s. Params: %s." % (self, e, url, params))
 
     def _post(self, url, **kwargs):
         try:

--- a/gold_digger/data_providers/currency_layer.py
+++ b/gold_digger/data_providers/currency_layer.py
@@ -28,12 +28,12 @@ class CurrencyLayer(Provider):
         :type date_of_exchange: datetime.date
         :rtype: set
         """
+        currencies = set()
         response = self._get("https://currencylayer.com/downloads/cl-currencies-table.txt")
         if response:
-            currencies = re.findall("<td>([A-Z]{3})</td>", response.text)
-            if currencies:
-                return set(currencies)
-        return set()
+            currencies = set(re.findall("<td>([A-Z]{3})</td>", response.text))
+        self.logger.debug("CurrencyLayer currencies: %s", currencies)
+        return currencies
 
     def get_by_date(self, date_of_exchange, currency):
         date_str = date_of_exchange.strftime(format="%Y-%m-%d")

--- a/gold_digger/data_providers/currency_layer.py
+++ b/gold_digger/data_providers/currency_layer.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
+
+import re
 from collections import defaultdict
 from datetime import date, timedelta
+from functools import lru_cache
+
 from ._provider import Provider
 
 
@@ -17,6 +21,19 @@ class CurrencyLayer(Provider):
         super().__init__(*args, **kwargs)
         self._access_keys = access_keys
         self._url = self.BASE_URL % self._access_keys[1]
+
+    @lru_cache(maxsize=1)
+    def get_supported_currencies(self, date_of_exchange):
+        """
+        :type date_of_exchange: datetime.date
+        :rtype: set
+        """
+        response = self._get("https://currencylayer.com/downloads/cl-currencies-table.txt")
+        if response:
+            currencies = re.findall("<td>([A-Z]{3})</td>", response.text)
+            if currencies:
+                return set(currencies)
+        return set()
 
     def get_by_date(self, date_of_exchange, currency):
         date_str = date_of_exchange.strftime(format="%Y-%m-%d")

--- a/gold_digger/data_providers/currency_layer.py
+++ b/gold_digger/data_providers/currency_layer.py
@@ -19,8 +19,11 @@ class CurrencyLayer(Provider):
 
     def __init__(self, access_keys, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._access_keys = access_keys
-        self._url = self.BASE_URL % self._access_keys[1]
+        try:
+            self._url = self.BASE_URL % access_keys[1]
+        except IndexError:
+            self.logger.critical("You need an access token to use CurrencyLayer provider!")
+            self._url = self.BASE_URL % ""
 
     @lru_cache(maxsize=1)
     def get_supported_currencies(self, date_of_exchange):

--- a/gold_digger/data_providers/currency_layer.py
+++ b/gold_digger/data_providers/currency_layer.py
@@ -32,7 +32,10 @@ class CurrencyLayer(Provider):
         response = self._get("https://currencylayer.com/downloads/cl-currencies-table.txt")
         if response:
             currencies = set(re.findall("<td>([A-Z]{3})</td>", response.text))
-        self.logger.debug("CurrencyLayer currencies: %s", currencies)
+        if currencies:
+            self.logger.debug("CurrencyLayer supported currencies: %s", currencies)
+        else:
+            self.logger.error("CurrencyLayer supported currencies not found.")
         return currencies
 
     def get_by_date(self, date_of_exchange, currency):

--- a/gold_digger/data_providers/fixer.py
+++ b/gold_digger/data_providers/fixer.py
@@ -21,7 +21,10 @@ class Fixer(Provider):
         response = self._get(self.BASE_URL.format(date=date_of_exchange))
         if response:
             currencies = set(response.json().get("rates").keys())
-        self.logger.debug("Fixer currencies: %s", currencies)
+        if currencies:
+            self.logger.debug("Fixer supported currencies: %s", currencies)
+        else:
+            self.logger.error("Fixer supported currencies not found.")
         return currencies
 
     def get_by_date(self, date_of_exchange, currency):

--- a/gold_digger/data_providers/fixer.py
+++ b/gold_digger/data_providers/fixer.py
@@ -87,3 +87,6 @@ class Fixer(Provider):
                 self.logger.exception("Fixer.io - Exception while parsing of the HTTP response.")
 
         return None
+
+    def __str__(self):
+        return self.name

--- a/gold_digger/data_providers/fixer.py
+++ b/gold_digger/data_providers/fixer.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from datetime import date, timedelta
+from functools import lru_cache
 
 from ._provider import Provider
 
@@ -9,6 +10,17 @@ class Fixer(Provider):
     BASE_CURRENCY = "USD"
     BASE_URL = "https://api.fixer.io/{date}"
     name = "fixer.io"
+
+    @lru_cache(maxsize=1)
+    def get_supported_currencies(self, date_of_exchange):
+        """
+        :type date_of_exchange: datetime.date
+        :rtype: set
+        """
+        response = self._get(self.BASE_URL.format(date=date_of_exchange))
+        if response:
+            return set(response.json().get("rates").keys())
+        return set()
 
     def get_by_date(self, date_of_exchange, currency):
         """

--- a/gold_digger/data_providers/fixer.py
+++ b/gold_digger/data_providers/fixer.py
@@ -17,10 +17,12 @@ class Fixer(Provider):
         :type date_of_exchange: datetime.date
         :rtype: set
         """
+        currencies = set()
         response = self._get(self.BASE_URL.format(date=date_of_exchange))
         if response:
-            return set(response.json().get("rates").keys())
-        return set()
+            currencies = set(response.json().get("rates").keys())
+        self.logger.debug("Fixer currencies: %s", currencies)
+        return currencies
 
     def get_by_date(self, date_of_exchange, currency):
         """

--- a/gold_digger/data_providers/google.py
+++ b/gold_digger/data_providers/google.py
@@ -26,7 +26,10 @@ class Google(Provider):
         response = self._get("https://finance.google.com/finance/converter")
         if response:
             currencies = set(re.findall('<option +value="([A-Z]{3})">', response.text))
-        self.logger.debug("Google currencies: %s", currencies)
+        if currencies:
+            self.logger.debug("Google supported currencies: %s", currencies)
+        else:
+            self.logger.error("Google supported currencies not found.")
         return currencies
 
     def get_by_date(self, date_of_exchange, currency):

--- a/gold_digger/data_providers/google.py
+++ b/gold_digger/data_providers/google.py
@@ -22,11 +22,12 @@ class Google(Provider):
         :type date_of_exchange: datetime.date
         :rtype: set
         """
+        currencies = set()
         response = self._get("https://finance.google.com/finance/converter")
         if response:
-            currencies = re.findall('<option +value="([A-Z]{3})">', response.text)
-            return set(currencies)
-        return set()
+            currencies = set(re.findall('<option +value="([A-Z]{3})">', response.text))
+        self.logger.debug("Google currencies: %s", currencies)
+        return currencies
 
     def get_by_date(self, date_of_exchange, currency):
         date_str = date_of_exchange.strftime(format="%Y-%m-%d")

--- a/gold_digger/data_providers/grandtrunk.py
+++ b/gold_digger/data_providers/grandtrunk.py
@@ -26,7 +26,10 @@ class GrandTrunk(Provider):
         response = self._get("{url}/currencies".format(url=self.BASE_URL))
         if response:
             currencies = set(response.text.split("\n"))
-        self.logger.debug("Grandtrunk currencies: %s", currencies)
+        if currencies:
+            self.logger.debug("Grandtrunk supported currencies: %s", currencies)
+        else:
+            self.logger.error("Grandtrunk supported currencies not found.")
         return currencies
 
     def get_by_date(self, date_of_exchange, currency):

--- a/gold_digger/data_providers/grandtrunk.py
+++ b/gold_digger/data_providers/grandtrunk.py
@@ -22,10 +22,12 @@ class GrandTrunk(Provider):
         :type date_of_exchange: date
         :rtype: set
         """
+        currencies = set()
         response = self._get("{url}/currencies".format(url=self.BASE_URL))
         if response:
-            return set(response.text.split("\n"))
-        return set()
+            currencies = set(response.text.split("\n"))
+        self.logger.debug("Grandtrunk currencies: %s", currencies)
+        return currencies
 
     def get_by_date(self, date_of_exchange, currency):
         date_str = date_of_exchange.strftime(format="%Y-%m-%d")

--- a/gold_digger/data_providers/grandtrunk.py
+++ b/gold_digger/data_providers/grandtrunk.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime, date
+
 from collections import defaultdict
+from datetime import datetime, date
+from functools import lru_cache
+
 from ._provider import Provider
 
 
@@ -12,6 +15,17 @@ class GrandTrunk(Provider):
     BASE_URL = "http://currencies.apps.grandtrunk.net"
     BASE_CURRENCY = "USD"
     name = "grandtrunk"
+
+    @lru_cache(maxsize=1)
+    def get_supported_currencies(self, date_of_exchange):
+        """
+        :type date_of_exchange: date
+        :rtype: set
+        """
+        response = self._get("{url}/currencies".format(url=self.BASE_URL))
+        if response:
+            return set(response.text.split("\n"))
+        return set()
 
     def get_by_date(self, date_of_exchange, currency):
         date_str = date_of_exchange.strftime(format="%Y-%m-%d")

--- a/gold_digger/data_providers/yahoo.py
+++ b/gold_digger/data_providers/yahoo.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+
 from datetime import date
+from functools import lru_cache
+
 from ._provider import Provider
 
 
@@ -15,6 +18,19 @@ class Yahoo(Provider):
         "format": "json"
     }
     name = "yahoo"
+
+    def __init__(self, currencies, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._currencies = currencies
+
+    @lru_cache(maxsize=1)
+    def get_supported_currencies(self, date_of_exchange):
+        """
+        :type date_of_exchange: date
+        :rtype: set
+        """
+        rates = self._get_all_latest(self._currencies)
+        return set(rates.keys())
 
     def get_by_date(self, date_of_exchange, currency):
         date_str = date_of_exchange.strftime(format="%Y-%m-%d")

--- a/gold_digger/data_providers/yahoo.py
+++ b/gold_digger/data_providers/yahoo.py
@@ -30,7 +30,9 @@ class Yahoo(Provider):
         :rtype: set
         """
         rates = self._get_all_latest(self._currencies)
-        return set(rates.keys())
+        currencies = set(rates.keys())
+        self.logger.debug("Yahoo currencies: %s", currencies)
+        return currencies
 
     def get_by_date(self, date_of_exchange, currency):
         date_str = date_of_exchange.strftime(format="%Y-%m-%d")

--- a/gold_digger/data_providers/yahoo.py
+++ b/gold_digger/data_providers/yahoo.py
@@ -31,7 +31,10 @@ class Yahoo(Provider):
         """
         rates = self._get_all_latest(self._currencies)
         currencies = set(rates.keys())
-        self.logger.debug("Yahoo currencies: %s", currencies)
+        if currencies:
+            self.logger.debug("Yahoo supported currencies: %s", currencies)
+        else:
+            self.logger.error("Yahoo supported currencies not found.")
         return currencies
 
     def get_by_date(self, date_of_exchange, currency):

--- a/gold_digger/managers/exchange_rate_manager.py
+++ b/gold_digger/managers/exchange_rate_manager.py
@@ -8,6 +8,13 @@ from collections import defaultdict, Counter
 
 class ExchangeRateManager:
     def __init__(self, dao_exchange_rate, dao_provider, data_providers, supported_currencies, logger):
+        """
+        :type dao_exchange_rate: gold_digger.database.DaoExchangeRate
+        :type dao_provider: gold_digger.database.DaoProvider
+        :type data_providers: list[gold_digger.data_providers._provider.Provider]
+        :type supported_currencies: set[str]
+        :type logger: logging.Logger
+        """
         self._dao_exchange_rate = dao_exchange_rate
         self._dao_provider = dao_provider
         self._data_providers = data_providers
@@ -15,6 +22,9 @@ class ExchangeRateManager:
         self._logger = logger
 
     def update_all_rates_by_date(self, date_of_exchange):
+        """
+        :type date_of_exchange: datetime.date
+        """
         for data_provider in self._data_providers:
             try:
                 self._logger.info("Updating all today rates from %s provider" % data_provider)
@@ -28,6 +38,9 @@ class ExchangeRateManager:
                 self._logger.exception("Updating of all today rates from %s provider failed.")
 
     def update_all_historical_rates(self, origin_date):
+        """
+        :type origin_date: datetime.date
+        """
         for data_provider in self._data_providers:
             self._logger.info("Updating all historical rates from %s provider" % data_provider)
             date_rates = data_provider.get_historical(origin_date, self._supported_currencies)
@@ -40,6 +53,10 @@ class ExchangeRateManager:
         """
         Get records of exchange rates for the date from all data providers.
         If rates are missing for the date from some providers request data only from these providers to update database.
+
+        :type date_of_exchange: datetime.date
+        :type currency: str
+        :rtype: list[gold_digger.database.db_model.ExchangeRate]
         """
         today = date.today()
         exchange_rates = self._dao_exchange_rate.get_rates_by_date_currency(date_of_exchange, currency)
@@ -61,6 +78,9 @@ class ExchangeRateManager:
         Compare rates to each other and group then by absolute difference.
         If there is group with minimal difference of two rates, choose one of them according the order of providers.
         If there is group with minimal difference with more than two rates, choose rate in the middle / aka most common rate in the list.
+
+        :type rates_records: list[gold_digger.database.db_model.ExchangeRate]
+        :rtype: gold_digger.database.db_model.ExchangeRate
         """
         if len(rates_records) in (1, 2):
             return rates_records[0]
@@ -76,6 +96,10 @@ class ExchangeRateManager:
             return Counter(rates).most_common(1)[0][0]  # [(ExchangeRate, occurrences)]
 
     def future_date_to_today(self, date_of_exchange):
+        """
+        :type date_of_exchange: datetime.date
+        :rtype: datetime.date
+        """
         today = date.today()
         if date_of_exchange > today:
             self._logger.warning("Request for future date %s. Exchange rate of today will be returned instead.", date_of_exchange)
@@ -86,6 +110,11 @@ class ExchangeRateManager:
         """
         Compute exchange rate between 'from_currency' and 'to_currency'.
         If the date is missing request data providers to update database.
+
+        :type date_of_exchange: datetime.date
+        :type from_currency: str
+        :type to_currency: str
+        :rtype: Decimal
         """
         date_of_exchange = self.future_date_to_today(date_of_exchange)
 
@@ -107,6 +136,12 @@ class ExchangeRateManager:
         """
         Compute average exchange rate of currency in specified period.
         Log warnings for missing days.
+
+        :type start_date: datetime.date
+        :type end_date: datetime.date
+        :type from_currency: str
+        :type to_currency: str
+        :rtype: Decimal
         """
         today_or_past_date = self.future_date_to_today(start_date)
         if today_or_past_date != start_date:

--- a/gold_digger/managers/exchange_rate_manager.py
+++ b/gold_digger/managers/exchange_rate_manager.py
@@ -41,10 +41,13 @@ class ExchangeRateManager:
         Get records of exchange rates for the date from all data providers.
         If rates are missing for the date from some providers request data only from these providers to update database.
         """
+        today = date.today()
         exchange_rates = self._dao_exchange_rate.get_rates_by_date_currency(date_of_exchange, currency)
         exchange_rates_providers = set(r.provider.name for r in exchange_rates)
         missing_provider_rates = [provider for provider in self._data_providers if provider.name not in exchange_rates_providers]
         for data_provider in missing_provider_rates:
+            if currency not in data_provider.get_supported_currencies(today):
+                continue
             rate = data_provider.get_by_date(date_of_exchange, currency)
             if rate:
                 db_provider = self._dao_provider.get_or_create_provider_by_name(data_provider.name)

--- a/tests/test_exchange_rate_manager.py
+++ b/tests/test_exchange_rate_manager.py
@@ -33,18 +33,20 @@ def dao_provider():
 
 
 @pytest.fixture
-def currency_layer():
+def currency_layer(currencies):
     provider = Mock(CurrencyLayer)
     provider.name = "currency_layer"
     provider.get_all_by_date.return_value = {"EUR": Decimal(0.77), "USD": Decimal(1)}
+    provider.get_supported_currencies.return_value = currencies
     return provider
 
 
 @pytest.fixture
-def grandtrunk():
+def grandtrunk(currencies):
     provider = Mock(GrandTrunk)
     provider.name = "grandtrunk"
     provider.get_all_by_date.return_value = {"EUR": Decimal(0.75), "USD": Decimal(1)}
+    provider.get_supported_currencies.return_value = currencies
     return provider
 
 
@@ -97,7 +99,7 @@ def test_get_or_update_rate_by_date(dao_exchange_rate, dao_provider, currency_la
 def test_get_exchange_rate_by_date(dao_exchange_rate, dao_provider, logger):
     _date = date(2016, 2, 17)
 
-    exchange_rate_manager = ExchangeRateManager(dao_exchange_rate, dao_provider, [], [], logger)
+    exchange_rate_manager = ExchangeRateManager(dao_exchange_rate, dao_provider, [], set(), logger)
 
     def _get_rates_by_date_currency(date_of_exchange, currency):
         return {
@@ -122,7 +124,7 @@ def test_get_average_exchange_rate_by_dates(dao_exchange_rate, dao_provider, log
     _end_date = date(2016, 2, 17)
 
     mock_logger = Mock(logger)
-    exchange_rate_manager = ExchangeRateManager(dao_exchange_rate, dao_provider, [], [], mock_logger)
+    exchange_rate_manager = ExchangeRateManager(dao_exchange_rate, dao_provider, [], set(), mock_logger)
 
     def _get_sum_of_rates_in_period(start_date, end_date, currency):
         return {


### PR DESCRIPTION
https://is.roihunter.com/issues/18081

If a specific exchange rate miss from a provider, the provider is requested for the rate. But if the provider does not support rates for such currency, it will always fail and the process will be again repeated. We should find out what currencies are supported by which providers and we should avoid making of useless requests.

@business-factory/pythonistas please review & merge.