### PR TITLE
Do not run DB update by cron

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,12 +31,6 @@ RUN pip3 install -U pip wheel && \
 # Create local config file
 ADD gold_digger/config/params_local.py gold_digger/config/params_local.py
 
-# Setup cron for daily updates
-# Add crontab file in the cron directory
-ADD crontab.conf /etc/cron.d/daily-exchange-rates
-RUN chmod 600 /etc/cron.d/daily-exchange-rates
-RUN touch cron.log
-
 # Setup supervisor
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 RUN mkdir -p /var/log/gold-digger

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,10 +1,6 @@
 [supervisord]
 nodaemon=true
 
-[program:cron]
-command=cron -f
-autorestart=true
-
 [program:gold-digger]
 command=gunicorn --workers=4 --bind 0.0.0.0:8000 gold_digger.api_server.app:app
 directory=/gold-digger


### PR DESCRIPTION
This PR will turn off the old system cron.
Old system cron in old Docker container will be replaced by new python-cron in separated container.

@business-factory/pythonistas Please review and merge 