### PR TITLE
Fix Fixer - handle error in the response

### DIFF
--- a/gold_digger/managers/exchange_rate_manager.py
+++ b/gold_digger/managers/exchange_rate_manager.py
@@ -96,6 +96,9 @@ class ExchangeRateManager:
         :type rates_records: list[gold_digger.database.db_model.ExchangeRate]
         :rtype: gold_digger.database.db_model.ExchangeRate
         """
+        if not rates_records:
+            raise ValueError("Missing exchange rate.")
+
         if len(rates_records) in (1, 2):
             return rates_records[0]
 


### PR DESCRIPTION
It's sad, but we managed to exceed our monthly limit in a single day
and now we receive "usage_limit_reached" which should be handled properly.

https://logs.roihunter.com/messages/graylog2_1475/8b096262-ab0e-11e8-b72e-002590aa2115
https://logs.roihunter.com/messages/graylog2_1475/76be6d41-ab1e-11e8-b72e-002590aa2115

@business-factory/pythonistas please review & merge.