### PR TITLE
Fixes GrandTrunk provider

### DIFF
--- a/gold_digger/data_providers/grandtrunk.py
+++ b/gold_digger/data_providers/grandtrunk.py
@@ -22,7 +22,7 @@ class GrandTrunk(Provider):
         :rtype: set
         """
         currencies = set()
-        response = self._get("{url}/currencies".format(url=self.BASE_URL))
+        response = self._get("{url}/currencies/{date}".format(url=self.BASE_URL, date=date_of_exchange.strftime("%Y-%m-%d")))
         if response:
             currencies = set(response.text.split("\n"))
         if currencies:
@@ -42,13 +42,15 @@ class GrandTrunk(Provider):
 
     def get_all_by_date(self, date_of_exchange, currencies):
         day_rates = {}
+        supported_currencies = self.get_supported_currencies(date_of_exchange)
         for currency in currencies:
-            response = self._get("{url}/getrate/{date}/{from_currency}/{to}".format(
-                url=self.BASE_URL, date=date_of_exchange, from_currency=self.base_currency, to=currency))
-            if response:
-                decimal_value = self._to_decimal(response.text.strip(), currency)
-                if decimal_value:
-                    day_rates[currency] = decimal_value
+            if currency in supported_currencies:
+                response = self._get("{url}/getrate/{date}/{from_currency}/{to}".format(
+                    url=self.BASE_URL, date=date_of_exchange, from_currency=self.base_currency, to=currency))
+                if response:
+                    decimal_value = self._to_decimal(response.text.strip(), currency)
+                    if decimal_value:
+                        day_rates[currency] = decimal_value
         return day_rates
 
     def get_historical(self, origin_date, currencies):


### PR DESCRIPTION
This will fix errors messages from [logs](https://logs.roihunter.com/streams/56c6fa73e4b086ef4a3a7fca/search?rangetype=relative&fields=message%2Csource&width=1920&highlightMessage=&relative=432000&q=level%3A3+AND+%22grandtrunk%22).

GrandTrunk provides API of supported currencies by date. We was sending queries for all currencies even they don't exist or are no longer supported. 

Endpoint looks like:

```
http://currencies.apps.grandtrunk.net/currencies[/<date>]
```

> List of all supported currency codes, one per line. If <date> is provided, all supported currencies for that date are listed; when date is omitted all currencies are returned for which the rate on at least one date is known.

Source: http://currencies.apps.grandtrunk.net/

@business-factory/pythonistas 