### PR TITLE
Avoid doing too many requests to Fixer provider #28707

### DIFF
--- a/gold_digger/data_providers/_provider.py
+++ b/gold_digger/data_providers/_provider.py
@@ -99,6 +99,10 @@ class Provider(metaclass=ABCMeta):
         except InvalidOperation:
             logger.error("%s - Invalid operation: value %s is not a number (currency %s)", self, value, currency)
 
+    def set_request_limit_reached(self, logger):
+        logger.warning("%s - Requests limit exceeded.", self.name)
+        self.request_limit_reached = True
+
     def __str__(self):
         return self.name
 
@@ -110,10 +114,11 @@ class Provider(metaclass=ABCMeta):
         return date.today().day == 1
 
     @staticmethod
-    def check_request_limit(return_value):
+    def check_request_limit(return_value=None):
         """
-        Check request limit and prevent API call if the limit was exceeded. Logger index is position of logger in *args (without self).
-        :type return_value: {} | set | None
+        Check request limit and prevent API call if the limit was exceeded.
+
+        :type return_value: dict | set | None
         """
         def decorator(func):
             @wraps(func)
@@ -125,7 +130,7 @@ class Provider(metaclass=ABCMeta):
                 if not provider_instance.request_limit_reached:
                     return func(*args, **kwargs)
                 else:
-                    getcallargs(func, *args)["logger"].warning("{} API limit was exceeded. Rate won't be requested.".format(provider_instance.name))
+                    getcallargs(func, *args)["logger"].warning("%s API limit was exceeded. Rate won't be requested.", provider_instance.name)
                     return return_value
 
             return wrapper

--- a/gold_digger/data_providers/currency_layer.py
+++ b/gold_digger/data_providers/currency_layer.py
@@ -47,7 +47,7 @@ class CurrencyLayer(Provider):
             logger.error("CurrencyLayer supported currencies not found.")
         return currencies
 
-    @Provider.check_request_limit(None, name="CurrencyLayer", logger_index=2)
+    @Provider.check_request_limit(None)
     def get_by_date(self, date_of_exchange, currency, logger):
         """
         :type date_of_exchange: datetime.date
@@ -79,7 +79,7 @@ class CurrencyLayer(Provider):
         value = records.get("%s%s" % (self.base_currency, currency))
         return self._to_decimal(value, currency, logger=logger) if value is not None else None
 
-    @Provider.check_request_limit({}, name="CurrencyLayer", logger_index=2)
+    @Provider.check_request_limit({})
     def get_all_by_date(self, date_of_exchange, currencies, logger):
         """
         :type date_of_exchange: datetime.date
@@ -108,7 +108,7 @@ class CurrencyLayer(Provider):
                 day_rates[currency] = decimal_value
         return day_rates
 
-    @Provider.check_request_limit({}, name="CurrencyLayer", logger_index=2)
+    @Provider.check_request_limit({})
     def get_historical(self, origin_date, currencies, logger):
         """
         :type origin_date: datetime.date

--- a/gold_digger/data_providers/fixer.py
+++ b/gold_digger/data_providers/fixer.py
@@ -29,7 +29,7 @@ class Fixer(Provider):
             logger.critical("You need an access token to use Fixer provider!")
             self._url = self.BASE_URL % ""
 
-    @Provider.check_request_limit(set(), name="Fixer.io", logger_index=1)
+    @Provider.check_request_limit(set())
     @cachedmethod(cache=attrgetter("_cache"), key=lambda date_of_exchange, _: keys.hashkey(date_of_exchange))
     def get_supported_currencies(self, date_of_exchange, logger):
         """
@@ -70,7 +70,7 @@ class Fixer(Provider):
         date_of_exchange_string = date_of_exchange.strftime("%Y-%m-%d")
         return self._get_by_date(date_of_exchange_string, currency, logger)
 
-    @Provider.check_request_limit({}, name="Fixer.io", logger_index=2)
+    @Provider.check_request_limit({})
     def get_all_by_date(self, date_of_exchange, currencies, logger):
         """
         :type date_of_exchange: datetime.date
@@ -146,7 +146,7 @@ class Fixer(Provider):
 
         return historical_rates
 
-    @Provider.check_request_limit(None, name="Fixer.io", logger_index=2)
+    @Provider.check_request_limit(None)
     def _get_by_date(self, date_of_exchange, currency, logger):
         """
         :type date_of_exchange: str

--- a/tests/data_providers/conftest.py
+++ b/tests/data_providers/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from gold_digger.data_providers import Fixer, RatesAPI, Yahoo, CurrencyLayer
+from gold_digger.data_providers import CurrencyLayer, Fixer, RatesAPI, Yahoo
 
 
 @pytest.fixture

--- a/tests/data_providers/conftest.py
+++ b/tests/data_providers/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from gold_digger.data_providers import Fixer, RatesAPI, Yahoo
+from gold_digger.data_providers import Fixer, RatesAPI, Yahoo, CurrencyLayer
 
 
 @pytest.fixture
@@ -18,3 +18,8 @@ def fixer(base_currency, logger):
 @pytest.fixture
 def rates_api(base_currency):
     return RatesAPI(base_currency)
+
+
+@pytest.fixture
+def currency_layer(base_currency, logger):
+    return CurrencyLayer("simple_access_key", logger, base_currency)

--- a/tests/data_providers/test_currency_layer.py
+++ b/tests/data_providers/test_currency_layer.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from datetime import date
+from decimal import Decimal
+from unittest.mock import Mock
+
+import pytest
+from requests import Response
+
+
+@pytest.fixture
+def response():
+    return Response()
+
+
+def test_fixer_reach_monthly_limit(currency_layer, response, logger):
+    """
+    Fixer free API has monthly requests limit. After the limit is reached, no calls to API should be made until the beginning of the next month.
+    Case: Firstly block upcoming requests by sending 104 error, then set today for the first day of a month and unblock requests.
+    """
+    response.status_code = 200
+    response._content = b"""
+    {
+        "success": false,
+        "error": {
+            "code": 104,
+            "type": "requests amount reached"
+        }
+    }
+    """
+
+    currency_layer._get = Mock()
+    currency_layer._get.return_value = response
+
+    rate = currency_layer.get_by_date(date(2019, 4, 29), "USD", logger)
+
+    assert currency_layer._requestLimitReached
+    assert currency_layer._get.call_count == 1
+    assert rate is None
+
+    rate = currency_layer.get_by_date(date(2019, 4, 29), "USD", logger)
+
+    assert currency_layer._get.call_count == 1
+    assert rate is None
+
+    currency_layer._get_today_day = Mock()
+    currency_layer._get_today_day.return_value = 1
+
+    response._content = b"""
+        {
+            "success": true,
+            "quotes": {
+                "USDUSD": 1
+            }
+        }
+        """
+
+    rate = currency_layer.get_by_date(date(2019, 4, 29), "USD", logger)
+
+    assert not currency_layer._requestLimitReached
+    assert currency_layer._get.call_count == 2
+    assert rate == Decimal('1')
+

--- a/tests/data_providers/test_currency_layer.py
+++ b/tests/data_providers/test_currency_layer.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from datetime import date
 from decimal import Decimal
 from unittest.mock import Mock
@@ -12,9 +13,9 @@ def response():
     return Response()
 
 
-def test_fixer_reach_monthly_limit(currency_layer, response, logger):
+def test_currency_layer__reach_monthly_limit(currency_layer, response, logger):
     """
-    Fixer free API has monthly requests limit. After the limit is reached, no calls to API should be made until the beginning of the next month.
+    Currency layer free API has monthly requests limit. After the limit is reached, no calls to API should be made until the beginning of the next month.
     Case: Firstly block upcoming requests by sending 104 error, then set today for the first day of a month and unblock requests.
     """
     response.status_code = 200
@@ -61,4 +62,3 @@ def test_fixer_reach_monthly_limit(currency_layer, response, logger):
     assert currency_layer.request_limit_reached is False
     assert currency_layer._get.call_count == 2
     assert rate == Decimal('1')
-

--- a/tests/data_providers/test_currency_layer.py
+++ b/tests/data_providers/test_currency_layer.py
@@ -6,8 +6,6 @@ from unittest.mock import Mock
 import pytest
 from requests import Response
 
-from gold_digger.data_providers import Provider
-
 
 @pytest.fixture
 def response():
@@ -33,6 +31,9 @@ def test_fixer_reach_monthly_limit(currency_layer, response, logger):
     currency_layer._get = Mock()
     currency_layer._get.return_value = response
 
+    currency_layer.is_first_day_of_month = Mock()
+    currency_layer.is_first_day_of_month.return_value = False
+
     rate = currency_layer.get_by_date(date(2019, 4, 29), "USD", logger)
 
     assert currency_layer.request_limit_reached is True
@@ -44,9 +45,6 @@ def test_fixer_reach_monthly_limit(currency_layer, response, logger):
     assert currency_layer._get.call_count == 1
     assert rate is None
 
-    Provider._get_today_day = Mock()
-    Provider._get_today_day.return_value = 1
-
     response._content = b"""
         {
             "success": true,
@@ -55,6 +53,8 @@ def test_fixer_reach_monthly_limit(currency_layer, response, logger):
             }
         }
         """
+
+    currency_layer.is_first_day_of_month.return_value = True
 
     rate = currency_layer.get_by_date(date(2019, 4, 29), "USD", logger)
 

--- a/tests/data_providers/test_currency_layer.py
+++ b/tests/data_providers/test_currency_layer.py
@@ -6,6 +6,8 @@ from unittest.mock import Mock
 import pytest
 from requests import Response
 
+from gold_digger.data_providers import Provider
+
 
 @pytest.fixture
 def response():
@@ -33,7 +35,7 @@ def test_fixer_reach_monthly_limit(currency_layer, response, logger):
 
     rate = currency_layer.get_by_date(date(2019, 4, 29), "USD", logger)
 
-    assert currency_layer._requestLimitReached
+    assert currency_layer.request_limit_reached is True
     assert currency_layer._get.call_count == 1
     assert rate is None
 
@@ -42,8 +44,8 @@ def test_fixer_reach_monthly_limit(currency_layer, response, logger):
     assert currency_layer._get.call_count == 1
     assert rate is None
 
-    currency_layer._get_today_day = Mock()
-    currency_layer._get_today_day.return_value = 1
+    Provider._get_today_day = Mock()
+    Provider._get_today_day.return_value = 1
 
     response._content = b"""
         {
@@ -56,7 +58,7 @@ def test_fixer_reach_monthly_limit(currency_layer, response, logger):
 
     rate = currency_layer.get_by_date(date(2019, 4, 29), "USD", logger)
 
-    assert not currency_layer._requestLimitReached
+    assert currency_layer.request_limit_reached is False
     assert currency_layer._get.call_count == 2
     assert rate == Decimal('1')
 

--- a/tests/data_providers/test_fixer.py
+++ b/tests/data_providers/test_fixer.py
@@ -6,8 +6,6 @@ from unittest.mock import Mock
 import pytest
 from requests import Response
 
-from gold_digger.data_providers import Provider
-
 
 @pytest.fixture
 def response():
@@ -55,6 +53,9 @@ def test_fixer_reach_monthly_limit(fixer, response, logger):
     fixer._get = Mock()
     fixer._get.return_value = response
 
+    fixer.is_first_day_of_month = Mock()
+    fixer.is_first_day_of_month.return_value = False
+
     rate = fixer.get_by_date(date(2019, 4, 29), "USD", logger)
 
     assert fixer.request_limit_reached is True
@@ -80,8 +81,7 @@ def test_fixer_reach_monthly_limit(fixer, response, logger):
         }
         """
 
-    Provider._get_today_day = Mock()
-    Provider._get_today_day.return_value = 1
+    fixer.is_first_day_of_month.return_value = True
 
     rate = fixer.get_by_date(date(2019, 4, 29), "USD", logger)
 

--- a/tests/data_providers/test_fixer.py
+++ b/tests/data_providers/test_fixer.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from datetime import date
 from decimal import Decimal
 from unittest.mock import Mock
@@ -29,7 +30,6 @@ def test_fixer_conversion_to_base_currency(fixer, logger):
       }
     }
     """
-
     converted_rate = fixer._conversion_to_base_currency(Decimal(1.125138), Decimal(319.899055), logger)
     assert converted_rate == Decimal('284.3198389886396014034013616')
 
@@ -88,4 +88,3 @@ def test_fixer_reach_monthly_limit(fixer, response, logger):
     assert fixer.request_limit_reached is False
     assert fixer._get.call_count == 2
     assert rate == Decimal('1')
-

--- a/tests/data_providers/test_fixer.py
+++ b/tests/data_providers/test_fixer.py
@@ -1,6 +1,15 @@
 # -*- coding: utf-8 -*-
-
+from datetime import date
 from decimal import Decimal
+from unittest.mock import Mock
+
+import pytest
+from requests import Response
+
+
+@pytest.fixture
+def response():
+    return Response()
 
 
 def test_fixer_conversion_to_base_currency(fixer, logger):
@@ -23,3 +32,58 @@ def test_fixer_conversion_to_base_currency(fixer, logger):
 
     converted_rate = fixer._conversion_to_base_currency(Decimal(1.125138), Decimal(319.899055), logger)
     assert converted_rate == Decimal('284.3198389886396014034013616')
+
+
+def test_fixer_reach_monthly_limit(fixer, response, logger):
+    """
+    Fixer free API has monthly requests limit. After the limit is reached, no calls to API should be made until the beginning of the next month.
+    Case: Firstly block upcoming requests by sending 104 error, then set today for the first day of a month and unblock requests.
+    """
+    response.status_code = 200
+    response._content = b"""
+    {
+        "success": false,
+        "error": {
+            "code": 104,
+            "type": "requests amount reached"
+        }
+    }
+    """
+
+    fixer._get = Mock()
+    fixer._get.return_value = response
+
+    rate = fixer.get_by_date(date(2019, 4, 29), "USD", logger)
+
+    assert fixer._requestLimitReached
+    assert fixer._get.call_count == 1
+    assert rate is None
+
+    rate = fixer.get_by_date(date(2019, 4, 29), "USD", logger)
+
+    assert fixer._get.call_count == 1
+    assert rate is None
+
+    fixer._get_today_day = Mock()
+    fixer._get_today_day.return_value = 1
+
+    response._content = b"""
+        {
+            "success": true,
+            "timestamp": 1553731199,
+            "historical": true,
+            "base": "EUR",
+            "date": "2019-03-27",
+            "rates": {
+                "HUF": 319.899055,
+                "USD": 1.125138
+            }
+        }
+        """
+
+    rate = fixer.get_by_date(date(2019, 4, 29), "USD", logger)
+
+    assert not fixer._requestLimitReached
+    assert fixer._get.call_count == 2
+    assert rate == Decimal('1')
+

--- a/tests/test_exchange_rate_manager.py
+++ b/tests/test_exchange_rate_manager.py
@@ -148,8 +148,9 @@ def test_get_or_update_rate_by_date__today_before_cron_update(dao_exchange_rate,
     assert len(exchange_rates) == 2
 
 
-def test_get_or_update_rate_by_date__today_before_cron_update_no_yesterday_rates(dao_exchange_rate, dao_provider, currency_layer, grandtrunk, base_currency,
-                                                                                currencies, logger):
+def test_get_or_update_rate_by_date__today_before_cron_update_no_yesterday_rates(
+    dao_exchange_rate, dao_provider, currency_layer, grandtrunk, base_currency, currencies, logger
+):
     """
     Get all rates by date.
 


### PR DESCRIPTION
https://is.roihunter.com/issues/28707

All providers:
If there are rates unavailable for current day for some provider, use rates from previous day for this provider. In case there are no rates even for previous day, request API.

Fixer:
There is 1000 requests per month usage limit and when this limit was reached, we still made pointless requests to the API. Now, when the API responses with `error 104`, flag is set and all upcoming requests are blocked until the first day of the next month. From outside of the provider it looks like there are no supported currencies and no rates available.

Currency layer:
There is the same requests monthly limit as with Fixer. The same changes were made.