### PR TITLE
FIX: Use cachetools instead of lru_cache

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 cached-property = "~=1.5.1"
+cachetools = "~=3.1.0"
 click = "==6.2"
 croniter = "==0.3.20"
 falcon = "~=1.4.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a33b0fea755a226f56e8e5ed9d5f1f0f1a500d00023b62f348c976945d429cc1"
+            "sha256": "69ac1269ee58d4bf3d7daed4931f04b191448c10fecd5a8fd1e39399d3849d84"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -21,6 +21,14 @@
             ],
             "index": "pypi",
             "version": "==1.5.1"
+        },
+        "cachetools": {
+            "hashes": [
+                "sha256:219b7dc6024195b6f2bc3d3f884d1fef458745cd323b04165378622dcc823852",
+                "sha256:9efcc9fab3b49ab833475702b55edd5ae07af1af7a4c627678980b45e459c460"
+            ],
+            "index": "pypi",
+            "version": "==3.1.0"
         },
         "certifi": {
             "hashes": [
@@ -182,6 +190,14 @@
                 "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
             "version": "==19.1.0"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
+                "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==0.4.1"
         },
         "coverage": {
             "hashes": [

--- a/gold_digger/data_providers/_provider.py
+++ b/gold_digger/data_providers/_provider.py
@@ -5,6 +5,7 @@ from decimal import Decimal, InvalidOperation
 
 import requests
 import requests.exceptions
+from cachetools import Cache
 
 
 class Provider(metaclass=ABCMeta):
@@ -15,6 +16,8 @@ class Provider(metaclass=ABCMeta):
         :type base_currency: str
         """
         self._base_currency = base_currency
+
+        self._cache = Cache(maxsize=1)
 
     @property
     def base_currency(self):

--- a/gold_digger/data_providers/currency_layer.py
+++ b/gold_digger/data_providers/currency_layer.py
@@ -3,7 +3,9 @@
 import re
 from collections import defaultdict
 from datetime import date, timedelta
-from functools import lru_cache
+from operator import attrgetter
+
+from cachetools import cachedmethod, keys
 
 from ._provider import Provider
 
@@ -28,7 +30,7 @@ class CurrencyLayer(Provider):
             logger.critical("You need an access token to use CurrencyLayer provider!")
             self._url = self.BASE_URL % ""
 
-    @lru_cache(maxsize=1)
+    @cachedmethod(cache=attrgetter("_cache"), key=lambda date_of_exchange, _: keys.hashkey(date_of_exchange))
     def get_supported_currencies(self, date_of_exchange, logger):
         """
         :type date_of_exchange: datetime.date

--- a/gold_digger/data_providers/grandtrunk.py
+++ b/gold_digger/data_providers/grandtrunk.py
@@ -2,7 +2,9 @@
 
 from collections import defaultdict
 from datetime import datetime, date
-from functools import lru_cache
+from operator import attrgetter
+
+from cachetools import cachedmethod, keys
 
 from ._provider import Provider
 
@@ -15,7 +17,7 @@ class GrandTrunk(Provider):
     BASE_URL = "http://currencies.apps.grandtrunk.net"
     name = "grandtrunk"
 
-    @lru_cache(maxsize=1)
+    @cachedmethod(cache=attrgetter("_cache"), key=lambda date_of_exchange, _: keys.hashkey(date_of_exchange))
     def get_supported_currencies(self, date_of_exchange, logger):
         """
         :type date_of_exchange: date

--- a/gold_digger/data_providers/rates_api.py
+++ b/gold_digger/data_providers/rates_api.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from datetime import date, timedelta
-from functools import lru_cache
+from operator import attrgetter
 
 import requests
+from cachetools import cachedmethod, keys
 
 from ._provider import Provider
 
@@ -16,7 +17,7 @@ class RatesAPI(Provider):
     BASE_URL = "http://api.ratesapi.io/api/{date}"
     name = "rates_api"
 
-    @lru_cache(maxsize=1)
+    @cachedmethod(cache=attrgetter("_cache"), key=lambda date_of_exchange, _: keys.hashkey(date_of_exchange))
     def get_supported_currencies(self, date_of_exchange, logger):
         """
         :type date_of_exchange: datetime.date


### PR DESCRIPTION
Cache key for lru_cache is computed also from logger and changes with flow ID.

@business-factory/pythonistas 🙏 👍 🐍 